### PR TITLE
GoGoDuck runs on port 8300

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -11,6 +11,8 @@ grails.project.source.level = 1.6
 //   run: [maxMemory:1024, minMemory:64, debug:false, maxPerm:256]
 //]
 
+grails.server.port.http = "8300"
+
 grails.project.dependency.resolution = {
     // inherit Grails' default dependencies
     inherits("global") {


### PR DESCRIPTION
Fixed port so by default you can run GoGoDuck alongside Portal
