### PR TITLE
not subsetting on TIME in default profile, already done with geoserver requet

### DIFF
--- a/web-app/resources/worker/profiles/default
+++ b/web-app/resources/worker/profiles/default
@@ -11,6 +11,21 @@ can_access_via_fs() {
     test -f $file
 }
 
+# removes attribute from a given subset
+# $1 - subset
+# $1 - attribute to remove
+remove_attribute() {
+    local subset=$1; shift
+    local attribute=$1; shift
+
+    local tmp_subset=`mktemp`
+    echo "$subset" | tr -s ";" "\n" > $tmp_subset
+    subset=`cat $tmp_subset | grep -v "^$attribute," | tr -s "\n" ";" | sed -e 's/;$//g'`
+    rm -f $tmp_subset
+
+    echo $subset
+}
+
 # formats output file with either a file:// prefix or http://data.aodn.org.au/
 # prefix, depending if we can or cannot access the files locally
 # $1 - list of urls file
@@ -71,6 +86,10 @@ get_list_of_urls() {
 get_subset_command() {
     local profile=$1; shift
     local subset="$1"; shift
+
+    # https://github.com/aodn/aodn-portal/issues/1093
+    subset=`remove_attribute $subset TIME`
+
     # LATITUDE,-33.433849,-30.150743;LONGTITUDE,113.15197,115.741219 becomes:
     # -d LATITUDE,-33.433849,-30.150743 -d LONGTITUDE,113.15197,115.741219
     local ncks_arguments="-d "`echo $subset | sed -e 's/;$//' -e 's/;/ -d /g'`

--- a/web-app/resources/worker/shunit2_test.sh
+++ b/web-app/resources/worker/shunit2_test.sh
@@ -89,6 +89,21 @@ test_get_files_acorn() {
     rm -f $tmp_file
 }
 
+# test the remove_attribute function in profiles/default
+test_remove_attribute() {
+    source profiles/default
+    local subset="TIME,2014-04-14T03:00:00.000Z,2014-04-14T07:00:00.000Z;LATITUDE,-90.0,90.0;LONGITUDE,-180.0,180.0"
+
+    local subset_tmp=`remove_attribute $subset TIME`
+    assertTrue 'remove TIME' "[ '$subset_tmp' = 'LATITUDE,-90.0,90.0;LONGITUDE,-180.0,180.0' ]"
+
+    local subset_tmp=`remove_attribute $subset LATITUDE`
+    assertTrue 'remove LATITUDE' "[ '$subset_tmp' = 'TIME,2014-04-14T03:00:00.000Z,2014-04-14T07:00:00.000Z;LONGITUDE,-180.0,180.0' ]"
+
+    local subset_tmp=`remove_attribute $subset LONGITUDE`
+    assertTrue 'remove LONGITUDE' "[ '$subset_tmp' = 'TIME,2014-04-14T03:00:00.000Z,2014-04-14T07:00:00.000Z;LATITUDE,-90.0,90.0' ]"
+}
+
 # test file limit in gogoduck, not allowing processing of too many files
 test_file_limit() {
     source $GOGODUCK_NO_MAIN


### PR DESCRIPTION
Fix for #53.

Sneaky bug. Some gogoduck core modifications required for this fix.

Basically we will not have `-d TIME` in the ncks command, but we also don't really need it. This is because the correct time constraint is already downloaded from geoserver. All that we need to subset on is the lat/lon parameters.

https://github.com/aodn/aodn-portal/issues/1093

Sample job that fails and triggers the bug:

```
{
  layerName: 'acorn_hourly_avg_turq_nonqc_timeseries_url',
  emailAddress: 'dan.fruehauf@utas.edu.au',
  subsetDescriptor: {
    temporalExtent: {
      start: "2014-04-02T05:00:00.000Z",
      end:   "2014-04-02T07:00:00.000Z",
    },
    spatialExtent: {
      north: '90.0',
      south: '-90.0',
      east:  '180.0',
      west:  '-180.0'
    }
  }
}
```
