### PR TITLE
Issue 57

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -69,6 +69,7 @@ job {
 
 worker {
     fileLimit = 100
+    maxGogoduckTimeMinutes = 15
     outputFilenamePrefixForUser = "IMOS-Aggregation-"
     outputFilename = "output.nc"
     reportFilename = "report.txt"

--- a/grails-app/jobs/au/org/emii/gogoduck/job/JobExecutorJob.groovy
+++ b/grails-app/jobs/au/org/emii/gogoduck/job/JobExecutorJob.groovy
@@ -26,6 +26,7 @@ class JobExecutorJob {
             job: job,
             outputFilename: jobStoreService.getAggrPath(job),
             reportFilename: jobStoreService.getReportPath(job),
+            maxGogoduckTimeMinutes: grailsApplication.config.worker.maxGogoduckTimeMinutes,
             fileLimit: grailsApplication.config.worker.fileLimit
         )
     }

--- a/src/groovy/au/org/emii/gogoduck/worker/Worker.groovy
+++ b/src/groovy/au/org/emii/gogoduck/worker/Worker.groovy
@@ -10,6 +10,7 @@ class Worker {
     String outputFilename
     String reportFilename
     Integer fileLimit
+    Integer maxGogoduckTimeMinutes
 
     void run(successHandler, failureHandler) {
 
@@ -50,7 +51,7 @@ class Worker {
 
         def proc = cmd.execute()
         proc.consumeProcessOutput(System.out, System.err)
-        proc.waitFor()
+        proc.waitForOrKill(maxGogoduckTimeMinutes * 60 * 1000) // Convert to ms
 
         return proc
     }


### PR DESCRIPTION
Fixing #57 by consuming the process' output and making sure it doesn't hang. Added a 15 minute limit for every job. Can be configured obviously.

Bonus of that fix: it now streams the progress of gogoduck.sh to `Catalina.out`.
