### PR TITLE
gogoduck worker can score jobs based on difficulty

### DIFF
--- a/web-app/resources/worker/profiles/default
+++ b/web-app/resources/worker/profiles/default
@@ -48,6 +48,33 @@ format_output_file() {
     fi
 }
 
+# returns profile weight, which will be a multiplier for the job score
+get_profile_weight() {
+    # by default use 1 - no multiplying
+    echo 1
+}
+
+# this function takes a subset and should output the estimated job score to the
+# given file
+# $1 - geoserver
+# $2 - profile
+# $3 - output file
+# $4 - subset
+get_score() {
+    local geoserver=$1; shift
+    local profile=$1; shift
+    local output_file=$1; shift
+    local subset="$1"; shift
+
+    get_list_of_urls $geoserver $profile $output_file "$subset"
+
+    local -i job_score=`wc -l $output_file | cut -d' ' -f1`
+    local -i profile_weight=`get_profile_weight`
+    local -i job_score=`expr $job_score \* $profile_weight`
+
+    echo $job_score > $output_file
+}
+
 # this function takes a subset and should output the list of urls to the given
 # file
 # $1 - geoserver


### PR DESCRIPTION
This still requires more development in regard to:
 * Adjusting score accordingly for each data collection
 * Implementing queues depending on score

This PR simply lets you run:
```
./gogoduck.sh -g 'http://geoserver-123.aodn.org.au/geoserver' -p gsla_nrt00_timeseries_url -s "TIME,2011-10-10T00:00:00.000Z,2011-10-20T00:00:00.000Z;LATITUDE,-33.433849,-32.150743;LONGITUDE,114.15197,115.741219" -S -o score.txt
```
This will output the number of files need to be processed for the given job in `score.txt` (notice the **-S**).