### PR TITLE
add debug flag to ncrcat

### DIFF
--- a/web-app/resources/worker/gogoduck.sh
+++ b/web-app/resources/worker/gogoduck.sh
@@ -200,7 +200,7 @@ _aggregate() {
     if [ `ls -1 $dir/* | wc -l` -eq 1 ]; then
         mv $dir/* $output_file
     else
-        ncrcat -4 -h -O $dir/* $output_file
+        ncrcat -D2 -4 -h -O $dir/* $output_file
     fi
 }
 


### PR DESCRIPTION
Result in a bit more friendlier errors for `ncrcat` (concatenator). So instead of:
```
ncrcat: INFO/WARNING Multi-file concatenator encountered packing attribute add_offset for variable sea_surface_temperature. NCO copies the packing attributes from the first file to the output file. The packing attributes from the remaining files must match exactly those in the first file or data from subsequent files will not unpack correctly. Be sure all input files share the same packing attributes. If in doubt, unpack (with ncpdq -U) the input files, then concatenate them, then pack the result (with ncpdq). This message is printed only once per invocation.
ERROR: nco_inq_varid() reports requested variable "sst_count" is not defined in file
nco_err_exit(): ERROR Short NCO-generated message (usually name of function that triggered error): nco_inq_varid()
nco_err_exit(): ERROR Error code is -49. Translation into English with nc_strerror(-49) is "NetCDF: Variable not found"
nco_err_exit(): ERROR NCO will now exit with system call exit(EXIT_FAILURE)
```

We'll get something like:
```
ncrcat: INFO Build compiler lacked (or user turned off) OpenMP support. Code will execute with single thread in Uni-Processor (UP) mode.
ncrcat: INFO Extended filetype of bogus_aerosol_dynamic_indicator/20130831032000-ABOM-L3S_GHRSST-SSTskin-AVHRR_D-1d_day-v02.0-fv02.0.nc is NC_FORMAT_HDF5, mode = 4096
ncrcat: CONVENTION File "Conventions" attribute is "CF-1.7"
ncrcat: CONVENTION File "Conventions" attribute is "CF-1.7"
ncrcat: INFO nco_fl_blocksize() reports preferred output filesystem I/O block size: 4096 bytes
ncrcat: INFO/WARNING Multi-file concatenator encountered packing attribute add_offset for variable sea_surface_temperature. NCO copies the packing attributes from the first file to the output file. The packing attributes from the remaining files must match exactly those in the first file or data from subsequent files will not unpack correctly. Be sure all input files share the same packing attributes. If in doubt, unpack (with ncpdq -U) the input files, then concatenate them, then pack the result (with ncpdq). This message is printed only once per invocation.
ncrcat: TIMER Metadata setup and file layout before main loop took    0.07 s
ncrcat: INFO Input file 0 is bogus_aerosol_dynamic_indicator/20130831032000-ABOM-L3S_GHRSST-SSTskin-AVHRR_D-1d_day-v02.0-fv02.0.nc
ncrcat: INFO Extended filetype of bogus_aerosol_dynamic_indicator/20130831032000-ABOM-L3S_GHRSST-SSTskin-AVHRR_D-1d_day-v02.0-fv02.0.nc is NC_FORMAT_HDF5, mode = 4096
ncrcat: INFO Input file 1 is bogus_aerosol_dynamic_indicator/20130901032000-ABOM-L3S_GHRSST-SSTskin-AVHRR_D-1d_day-v02.0-fv02.0.nc
ncrcat: INFO Extended filetype of bogus_aerosol_dynamic_indicator/20130901032000-ABOM-L3S_GHRSST-SSTskin-AVHRR_D-1d_day-v02.0-fv02.0.nc is NC_FORMAT_HDF5, mode = 4096
ncrcat: INFO Input file 2 is bogus_sst_count/20130113032000-ABOM-L3S_GHRSST-SSTskin-AVHRR_D-1d_day-v02.0-fv02.0.nc
ncrcat: INFO Extended filetype of bogus_sst_count/20130113032000-ABOM-L3S_GHRSST-SSTskin-AVHRR_D-1d_day-v02.0-fv02.0.nc is NC_FORMAT_HDF5, mode = 4096
ERROR: nco_inq_varid() reports requested variable "sst_count" is not defined in file
nco_err_exit(): ERROR Short NCO-generated message (usually name of function that triggered error): nco_inq_varid()
nco_err_exit(): ERROR Error code is -49. Translation into English with nc_strerror(-49) is "NetCDF: Variable not found"
nco_err_exit(): ERROR NCO will now exit with system call exit(EXIT_FAILURE)
```

Then we can actually know which file(s) had problems to concatenate.