### PR TITLE
return status link

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -45,8 +45,6 @@ grails.exceptionresolver.params.exclude = ['password']
 // configure auto-caching of queries by default (if false you can cache individual queries with 'cache: true')
 grails.hibernate.cache.queries = false
 
-grails.serverURL = "http://${InetAddress.localHost.hostAddress}:${server.port}/$appName"
-
 grails {
     mail {
         'default' {
@@ -108,6 +106,11 @@ environments {
             outputPath = 'jobs'
         }
     }
+
+    test {
+        grails.serverURL = "http://localhost:8080/$appName"
+    }
+
     production {
         grails.logging.jul.usebridge = false
     }

--- a/grails-app/controllers/au/org/emii/gogoduck/job/JobController.groovy
+++ b/grails-app/controllers/au/org/emii/gogoduck/job/JobController.groovy
@@ -17,7 +17,8 @@ class JobController {
         }
         else {
             jobExecutorService.register(job)
-            render(status: 200, text: job.toJsonString())
+            def jobPresenter = new JobPresenter(job, jobExecutorService, jobStoreService, { createLink(it) })
+            render status: 200, contentType: "text/json", text: jobPresenter.toJsonString()
         }
     }
 
@@ -29,6 +30,6 @@ class JobController {
             return
         }
 
-        [job: new JobPresenter(job, jobExecutorService, jobStoreService, { createLink(it) } )] 
+        [job: new JobPresenter(job, jobExecutorService, jobStoreService, { createLink(it) } )]
     }
 }

--- a/src/groovy/au/org/emii/gogoduck/job/JobPresenter.groovy
+++ b/src/groovy/au/org/emii/gogoduck/job/JobPresenter.groovy
@@ -1,11 +1,15 @@
 package au.org.emii.gogoduck.job
 
+import grails.converters.JSON
+
 /**
  * Adds in a few extra useful attributes for a client.
  */
 class JobPresenter extends HashMap {
     JobPresenter(job, jobExecutorService, jobStoreService, createLink) {
         super(job.properties)
+
+        addUrl(job, createLink)
 
         switch (job.status) {
             case (Status.NEW):
@@ -27,11 +31,20 @@ class JobPresenter extends HashMap {
         put('queuePosition', jobExecutorService.getQueuePosition(job) + 1)
     }
 
+    void addUrl(job, createLink) {
+        put('url', createLink(controller: 'job', action: 'show', id: job.uuid, absolute: true))
+    }
+
     void addAggrUrl(job, createLink) {
         put('aggrUrl', createLink(controller: 'aggr', action: 'show', id: job.uuid, absolute: true))
     }
 
     void addReport(job, jobStoreService) {
         put('report', jobStoreService.getReport(job))
+    }
+
+    public String toJsonString() {
+        def propertiesToSerialize = [ 'url', 'queuePosition', 'status' ]
+        return this.subMap(propertiesToSerialize) as JSON
     }
 }


### PR DESCRIPTION
GGD returns a status link after registering a job. Next step is to use this link in portal and display it to the user after he submits a job - so she can click on it without waiting for any emails.