### PR TITLE
tmp dir from java

### DIFF
--- a/src/groovy/au/org/emii/gogoduck/worker/Worker.groovy
+++ b/src/groovy/au/org/emii/gogoduck/worker/Worker.groovy
@@ -30,8 +30,11 @@ class Worker {
     }
 
     def getCmd() {
+        log.info "Temporary directory for gogoduck operation '${getTempDir()}'"
+
         def cmdOptions = String.format(
-            "${job.subsetCommandString} -o %s -u %s -l %s",
+            "${job.subsetCommandString} -t %s -o %s -u %s -l %s",
+            getTempDir(),
             outputFilename,
             reportFilename,
             fileLimit
@@ -40,6 +43,10 @@ class Worker {
         log.info("Command options: '${cmdOptions}'")
 
         shellCmd.call(cmdOptions)
+    }
+
+    String getTempDir() {
+        return System.getProperty("java.io.tmpdir")
     }
 
     Process execute(cmd) {

--- a/test/unit/au/org/emii/gogoduck/worker/WorkerSpec.groovy
+++ b/test/unit/au/org/emii/gogoduck/worker/WorkerSpec.groovy
@@ -14,6 +14,8 @@ class WorkerSpec extends Specification {
     def worker
 
     def setup() {
+        Worker.metaClass.getTempDir { -> "temp_dir" }
+
         testJob = TestHelper.createJob()
         worker = new Worker(job: testJob)
     }
@@ -29,7 +31,7 @@ class WorkerSpec extends Specification {
         )
 
         expect:
-        worker.getCmd() == "gogoduck.sh -p some_layer -s TIME,2013-11-20T00:30:00.000Z,2013-11-20T10:30:00.000Z;LATITUDE,-33.433849,-32.150743;LONGITUDE,114.15197,115.741219 -g geoserver_address -o output.nc -u report.txt -l 123"
+        worker.getCmd() == "gogoduck.sh -p some_layer -s TIME,2013-11-20T00:30:00.000Z,2013-11-20T10:30:00.000Z;LATITUDE,-33.433849,-32.150743;LONGITUDE,114.15197,115.741219 -g geoserver_address -t temp_dir -o output.nc -u report.txt -l 123"
     }
 
     def "generates command line from job when geoserver is null"() {
@@ -45,7 +47,7 @@ class WorkerSpec extends Specification {
         )
 
         expect:
-        worker.getCmd() == "gogoduck.sh -p some_layer -s TIME,2013-11-20T00:30:00.000Z,2013-11-20T10:30:00.000Z;LATITUDE,-33.433849,-32.150743;LONGITUDE,114.15197,115.741219 -o output.nc -u report.txt -l 123"
+        worker.getCmd() == "gogoduck.sh -p some_layer -s TIME,2013-11-20T00:30:00.000Z,2013-11-20T10:30:00.000Z;LATITUDE,-33.433849,-32.150743;LONGITUDE,114.15197,115.741219 -t temp_dir -o output.nc -u report.txt -l 123"
     }
 
     def "generates command line from job when geoserver is empty string"() {
@@ -61,7 +63,7 @@ class WorkerSpec extends Specification {
         )
 
         expect:
-        worker.getCmd() == "gogoduck.sh -p some_layer -s TIME,2013-11-20T00:30:00.000Z,2013-11-20T10:30:00.000Z;LATITUDE,-33.433849,-32.150743;LONGITUDE,114.15197,115.741219 -o output.nc -u report.txt -l 123"
+        worker.getCmd() == "gogoduck.sh -p some_layer -s TIME,2013-11-20T00:30:00.000Z,2013-11-20T10:30:00.000Z;LATITUDE,-33.433849,-32.150743;LONGITUDE,114.15197,115.741219 -t temp_dir -o output.nc -u report.txt -l 123"
     }
 
     def "runs command"() {

--- a/web-app/resources/worker/README.md
+++ b/web-app/resources/worker/README.md
@@ -24,7 +24,7 @@ $ ./gogoduck.sh -g 'http://geoserver-123.aodn.org.au/geoserver' -p acorn_hourly_
 
 Running on GSLA data:
 ```
-./gogoduck.sh -g 'http://geoserver-123.aodn.org.au/geoserver' -p gsla_nrt00_timeseries_url -s "TIME,2011-10-10T00:00:00.000Z,2011-10-20T00:00:00.000Z;LATITUDE,-33.433849,-32.150743;LONGITUDE,114.15197,115.741219" -o output.nc
+$ ./gogoduck.sh -g 'http://geoserver-123.aodn.org.au/geoserver' -p gsla_nrt00_timeseries_url -s "TIME,2011-10-10T00:00:00.000Z,2011-10-20T00:00:00.000Z;LATITUDE,-33.433849,-32.150743;LONGITUDE,114.15197,115.741219" -o output.nc
 ```
 
 ### CARS
@@ -35,12 +35,12 @@ if it runs when opendap is mounted, things will be significantly faster.
 
 Running on CARS data:
 ```
-./gogoduck.sh -g 'http://geoserver-123.aodn.org.au/geoserver' -p cars_world_monthly -s "TIME,2009-01-01T00:00:00.000Z,2009-12-25T23:04:00.000Z;LATITUDE,-33.433849,-32.150743;LONGITUDE,114.15197,115.741219" -o output.nc
+$ ./gogoduck.sh -g 'http://geoserver-123.aodn.org.au/geoserver' -p cars_world_monthly -s "TIME,2009-01-01T00:00:00.000Z,2009-12-25T23:04:00.000Z;LATITUDE,-33.433849,-32.150743;LONGITUDE,114.15197,115.741219" -o output.nc
 ```
 
 Running on CARS data with depth (notice the floating point for the depth parameter):
 ```
-./gogoduck.sh -g 'http://geoserver-123.aodn.org.au/geoserver' -p cars_world_monthly -s "TIME,2009-01-01T00:00:00.000Z,2009-12-25T23:04:00.000Z;LATITUDE,-33.433849,-32.150743;LONGITUDE,114.15197,115.741219;DEPTH,0.0,100.0" -o output.nc
+$ ./gogoduck.sh -g 'http://geoserver-123.aodn.org.au/geoserver' -p cars_world_monthly -s "TIME,2009-01-01T00:00:00.000Z,2009-12-25T23:04:00.000Z;LATITUDE,-33.433849,-32.150743;LONGITUDE,114.15197,115.741219;DEPTH,0.0,100.0" -o output.nc
 ```
 
 ## Unit Tests

--- a/web-app/resources/worker/gogoduck.sh
+++ b/web-app/resources/worker/gogoduck.sh
@@ -369,7 +369,8 @@ Options:
   -p, --profile              Profile to apply.
   -o, --output               Output file to use.
   -l, --limit                Maximum amount of file to allow processing of.
-  -u, --user-log             Output file for user logging."
+  -u, --user-log             Output file for user logging.
+  -t, --tmp-dir              Set TMPDIR for operation."
     exit 3
 }
 
@@ -378,7 +379,7 @@ Options:
 # "$@" - parameters, see usage
 main() {
     # parse options with getopt
-    local tmp_getops=`getopt -o hSg:s:p:o:l:u: --long help,score,geoserver:,subset:,profile:,output:,limit:,user-log: -- "$@"`
+    local tmp_getops=`getopt -o hSg:s:p:o:l:u:t: --long help,score,geoserver:,subset:,profile:,output:,limit:,user-log:,tmp-dir: -- "$@"`
     [ $? != 0 ] && usage
 
     eval set -- "$tmp_getops"
@@ -400,6 +401,7 @@ main() {
             -o|--output) output="$2"; shift 2;;
             -l|--limit) limit="$2"; shift 2;;
             -u|--user-log) user_log="$2"; shift 2;;
+            -t|--tmp-dir) export TMPDIR="$2"; shift 2;;
             --) shift; break;;
             *) usage;;
         esac

--- a/web-app/resources/worker/gogoduck.sh
+++ b/web-app/resources/worker/gogoduck.sh
@@ -349,7 +349,7 @@ gogoduck_main() {
     fi
 
     # clean up temporary directory
-    rm -f $tmp_dir/*; rmdir $tmp_dir
+    rm -f $tmp_url_list $tmp_dir/*; rmdir $tmp_dir
 
     mv $tmp_result_file $output
     logger_info "Result saved at '$output'"


### PR DESCRIPTION
By controlling the tmp directory, we can allow for larger jobs to run as they wouldn't run on `/tmp` but on the tomcat temp directory which has more space.