### PR TITLE
issue 1728 reason

### DIFF
--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -69,6 +69,7 @@ job.emailAddress.email.error=Please supply a valid email address
 job.id.label=Job Id
 job.createdTimestamp.label=Submitted
 job.status.label=Status
+job.reason.label=Reason
 job.queuePosition.label=Position in Queue
 job.aggrUrl.label=Download URL
 job.report.label=Report
@@ -77,5 +78,11 @@ job.status.NEW=New
 job.status.IN_PROGRESS=In Progress
 job.status.SUCCEEDED=Succeeded
 job.status.FAILED=Failed
+
+job.reason.NONE=
+job.reason.TIMEOUT_EXPIRED=Maximum processing time limit exceeded
+job.reason.TOO_MANY_FILES=Maximum file limit exceeded
+job.reason.GOGODUCK_CORE=Internal error running GoGoDuck, please refer to report for more information
+job.reason.UNKNOWN=Unexpected error; please report to info@emii.org.au
 
 aggregation.status=Aggregation Status

--- a/grails-app/services/au/org/emii/gogoduck/job/JobExecutorService.groovy
+++ b/grails-app/services/au/org/emii/gogoduck/job/JobExecutorService.groovy
@@ -56,14 +56,15 @@ class JobExecutorService {
     }
 
     def failureHandler = {
-        job ->
+        job, reason ->
 
-        setJobStatusAndSave(job, Status.FAILED)
+        setJobStatusAndSave(job, Status.FAILED, reason)
         notificationService.sendJobFailureNotification(getPresentedJob(job))
     }
 
-    def setJobStatusAndSave(job, status) {
+    def setJobStatusAndSave(job, status, reason = Reason.NONE) {
         job.status = status
+        job.reason = reason
         jobStoreService.save(job)
     }
 

--- a/grails-app/views/job/show.gsp
+++ b/grails-app/views/job/show.gsp
@@ -18,6 +18,11 @@
                 <g:labelledContent labelCode="job.id.label">${job.uuid}</g:labelledContent>
                 <g:labelledContent labelCode="job.createdTimestamp.label"><joda:format value="${job.createdTimestamp}" /></g:labelledContent>
                 <g:labelledContent labelCode="job.status.label"><g:message code="job.status.${job.status}" default="${job.status.toString()}" /></g:labelledContent>
+
+                <g:if test="${job.reason != job.reason.NONE}">
+                    <g:labelledContent labelCode="job.reason.label"><g:message code="job.reason.${job.reason}" default="${job.reason.toString()}" /></g:labelledContent>
+                </g:if>
+
                 <g:labelledContent if="${job.queuePosition}" labelCode="job.queuePosition.label">${job.queuePosition}</g:labelledContent>
                 <g:labelledContent if="${job.aggrUrl}" labelCode="job.aggrUrl.label">
                     <a href="${job.aggrUrl}">${job.aggrUrl}</a>

--- a/src/groovy/au/org/emii/gogoduck/job/Job.groovy
+++ b/src/groovy/au/org/emii/gogoduck/job/Job.groovy
@@ -4,6 +4,7 @@ import grails.converters.JSON
 import org.joda.time.DateTime
 
 import au.org.emii.gogoduck.json.JSONSerializer
+import au.org.emii.gogoduck.job.Reason
 
 @grails.validation.Validateable
 class Job {
@@ -17,6 +18,7 @@ class Job {
     DateTime startedTimestamp
     DateTime finishedTimestamp
     Status status
+    Reason reason
 
     // Need to instantiate nested objects, otherwise they are not bound.
     // See: http://grails.1312388.n4.nabble.com/How-to-bind-data-to-a-command-object-that-has-an-non-domain-object-as-property-tp4021559p4328826.html
@@ -33,6 +35,7 @@ class Job {
         uuid = UUID.randomUUID().toString()[0..7]
         createdTimestamp = DateTime.now()
         status = Status.NEW
+        reason = Reason.NONE
     }
 
     String toString() {

--- a/src/groovy/au/org/emii/gogoduck/job/Reason.groovy
+++ b/src/groovy/au/org/emii/gogoduck/job/Reason.groovy
@@ -1,0 +1,9 @@
+package au.org.emii.gogoduck.job
+
+enum Reason {
+    NONE,
+    TIMEOUT_EXPIRED,
+    TOO_MANY_FILES,
+    GOGODUCK_CORE,
+    UNKNOWN
+}

--- a/src/groovy/au/org/emii/gogoduck/json/JSONSerializer.groovy
+++ b/src/groovy/au/org/emii/gogoduck/json/JSONSerializer.groovy
@@ -20,12 +20,9 @@ class JSONSerializer {
         return json.toString(true)
     }
 
-    private buildJSON = {obj ->
-
-        obj.properties.each {propName, propValue ->
-
+    private buildJSON = { obj ->
+        obj.properties.sort().each {propName, propValue ->
             if (shouldSerialiseProperty(propName)) {
-
                 serialiseProperty.delegate = delegate
                 serialiseProperty(propName, propValue)
             }

--- a/test/unit/au/org/emii/gogoduck/job/JobExecutorServiceSpec.groovy
+++ b/test/unit/au/org/emii/gogoduck/job/JobExecutorServiceSpec.groovy
@@ -49,6 +49,7 @@ class JobExecutorServiceSpec extends Specification {
         then:
         1 * jobStoreService.save(job)
         job.status == Status.NEW
+        job.reason == Reason.NONE
     }
 
     def "run runs worker, sets status to IN_PROGRESS"() {
@@ -58,6 +59,7 @@ class JobExecutorServiceSpec extends Specification {
         then:
         1 * jobStoreService.save(job)
         job.status == Status.IN_PROGRESS
+        job.reason == Reason.NONE
     }
 
     def "success handler sends 'job success' notification, sets status to SUCCEEDED"() {
@@ -68,15 +70,17 @@ class JobExecutorServiceSpec extends Specification {
         1 * notificationService.sendJobSuccessNotification(job)
         1 * jobStoreService.save(job)
         job.status == Status.SUCCEEDED
+        job.reason == Reason.NONE
     }
 
     def "failed handler sends 'job failure' notification, sets status to FAILED"() {
         when:
-        service.failureHandler(job)
+        service.failureHandler(job, Reason.TIMEOUT_EXPIRED)
 
         then:
         1 * notificationService.sendJobFailureNotification(job)
         1 * jobStoreService.save(job)
         job.status == Status.FAILED
+        job.reason == Reason.TIMEOUT_EXPIRED
     }
 }

--- a/test/unit/au/org/emii/gogoduck/job/JobSpec.groovy
+++ b/test/unit/au/org/emii/gogoduck/job/JobSpec.groovy
@@ -28,6 +28,7 @@ class JobSpec extends Specification {
    },
    "createdTimestamp": "1970-01-01T11:00:01.234+11:00",
    "status": "NEW",
+   "reason": "NONE",
    "geoserver": "geoserver_address",
    "emailAddress": "gogo@duck.com",
    "layerName": "some_layer",

--- a/web-app/resources/worker/gogoduck.sh
+++ b/web-app/resources/worker/gogoduck.sh
@@ -318,7 +318,8 @@ gogoduck_main() {
     # enforce number of URLs limit
     if ! _enforce_file_limit $tmp_url_list $limit; then
         rm -f $tmp_url_list
-        logger_fatal "Not allowed to process that many files"
+        logger_warn "Not allowed to process that many files"
+        return 3 # Indicate too many files
     fi
 
     # temporary directory and temporary result
@@ -422,6 +423,7 @@ main() {
         gogoduck_score $geoserver "$profile" "$subset" $output
     else
         gogoduck_main $geoserver $limit "$profile" "$subset" "$output"
+        return $?
     fi
 }
 


### PR DESCRIPTION
Fixes https://github.com/aodn/aodn-portal/issues/1728 by providing a reason to the user as to why the aggregation failed.

The crux was to find out when a timeout occurred I think. Since `waitForOrKill` could not tell if a timeout occurred or it's just another failure. So now it's measuring the time it took for the job to run. If it actually exceeded the expectation it shows a timeout error.

gogoduck.sh now also returns a value of 3 when the file limit is reached. We can display that to the user in the nice error log, rather than let him figure it out from the report.

I hope that's the last GGD tweak we do before we rewrite in Java.