### PR TITLE
issue 103

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -102,8 +102,9 @@ environments {
                 [
                     'bash', '-c',
                     "echo bytes > ${outputFilename}; echo 'here be report' > ${reportFilename}"
+                    // Uncomment line to test error handling
+                    // + "; echo 'here be error' >&2; false"
                 ]
-                // "test/resources/error.sh" // Uncomment this to test error handling.
             }
             outputPath = 'jobs'
         }

--- a/grails-app/services/au/org/emii/gogoduck/job/JobStoreService.groovy
+++ b/grails-app/services/au/org/emii/gogoduck/job/JobStoreService.groovy
@@ -56,7 +56,13 @@ class JobStoreService {
     }
 
     String getReport(job) {
-        getReportFile(job).text
+        try {
+            return getReportFile(job).text
+        }
+        catch (Exception e) {
+            log.error "Error opening report file for '${job}'"
+            return ""
+        }
     }
 
     void makeDir(job) {

--- a/test/resources/error.sh
+++ b/test/resources/error.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-echo there was an error >&2
-exit 1
-


### PR DESCRIPTION
Fix issue #103

The problem stemmed from not catching an exception when `getReportFile` was called - because in the case of running in `development`, the file did not exist. So this is fixed and also mocking of errors is done in a better way. There will be a report this time regardless.