### PR TITLE
Fix incorrect mailto link

### DIFF
--- a/grails-app/views/job/show.gsp
+++ b/grails-app/views/job/show.gsp
@@ -40,7 +40,7 @@
                            please let us
                            know.
                            All feedback is very welcome. For help and information about this site
-                           please contact <a href="mailt:info@emii.org.au">info@emii.org.au</a></p>
+                           please contact <a href="mailto:info@emii.org.au">info@emii.org.au</a></p>
                     </div>
                     <div class="col-md-8">
                         <p>Use of this web site and information available from it is subject to our <a href="http://imos.org.au/imostermsofuse0.html">


### PR DESCRIPTION
The fact that this bug had to be fixed here as well as https://github.com/aodn/aodn-portal/pull/1995 (plus all the other duplication in taglib, gsp, styles) suggests extracting a grails plugin - but that has to be weighed up against the fact that ggd as we know it might be disappearing.